### PR TITLE
chore: ローカルでCI相当チェックを実行できる環境を追加

### DIFF
--- a/docs/operations/20260225-local-check-environment.md
+++ b/docs/operations/20260225-local-check-environment.md
@@ -1,0 +1,71 @@
+# ローカルチェック環境セットアップ / Local Check Environment Setup
+
+- Title: ローカルチェック環境セットアップ / Local Check Environment Setup
+- Status: Draft
+- Created: 2026-02-25
+- Last Updated: 2026-02-25
+- Owner: TBD
+- Language: JA/EN
+
+## 目的 / Objective
+
+GitHub Actions の `markdownlint` / `yamllint` / `shellcheck` /
+`scripts/check.sh` をローカルで再現し、PR前に失敗原因を検出できる
+状態を作る。
+
+## 前提条件 / Prerequisites
+
+- `bash`
+- `python3` と `pip`
+- `curl`
+- `tar` と `xz`
+
+## セットアップ手順 / Setup Steps
+
+```bash
+bash scripts/setup-local-check-env.sh
+```
+
+初回実行時に以下をインストールする。
+
+- Node.js（`~/.cache/ocrwebapp-local-checks/node`）
+- Python venv（`~/.cache/ocrwebapp-local-checks/venv`）
+- `markdownlint-cli2`
+- `yamllint`
+- `shellcheck`
+
+## チェック実行 / Run Checks
+
+```bash
+bash scripts/run-local-checks.sh
+```
+
+実行内容:
+
+- `bash scripts/check.sh`
+- `markdownlint-cli2 "**/*.md"`
+- `yamllint .`
+- `shellcheck scripts/*.sh`
+- `bash scripts/validate-branch-name.sh <current-branch>`
+
+## 更新方針 / Maintenance
+
+- ツールバージョンは `scripts/setup-local-check-env.sh` で管理する。
+- CI 側のツール更新時は、同一 PR でこの手順も更新する。
+
+## 概要 / Summary (JA)
+
+`scripts/setup-local-check-env.sh` と `scripts/run-local-checks.sh` により、CI 相当の静的チェックをローカルで実行できる。
+
+## Summary (EN)
+
+The local scripts provide a reproducible environment to run
+CI-equivalent lint and lightweight checks before opening a PR.
+
+## 結論 / Conclusion (JA)
+
+PR 送信前に `scripts/run-local-checks.sh` を実行し、失敗を先に解消する運用を基本とする。
+
+## Conclusion (EN)
+
+Run `scripts/run-local-checks.sh` before creating a PR and fix failures locally first.

--- a/scripts/run-local-checks.sh
+++ b/scripts/run-local-checks.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOLS_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/ocrwebapp-local-checks"
+ENV_FILE="$TOOLS_ROOT/env.sh"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Local check env is not initialized: $ENV_FILE" >&2
+  echo "Run: bash \"$REPO_ROOT/scripts/setup-local-check-env.sh\"" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "Missing command in local check env: $cmd" >&2
+    echo "Run: bash \"$REPO_ROOT/scripts/setup-local-check-env.sh\"" >&2
+    exit 1
+  }
+}
+
+require_cmd markdownlint-cli2
+require_cmd yamllint
+require_cmd shellcheck
+
+echo "[local-check] bash scripts/check.sh"
+bash "$REPO_ROOT/scripts/check.sh"
+
+echo "[local-check] markdownlint-cli2"
+markdownlint-cli2 "**/*.md"
+
+echo "[local-check] yamllint"
+yamllint .
+
+echo "[local-check] shellcheck"
+shellcheck "$REPO_ROOT"/scripts/*.sh
+
+echo "[local-check] branch name"
+branch_name="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+bash "$REPO_ROOT/scripts/validate-branch-name.sh" "$branch_name"
+
+echo "All local checks passed."

--- a/scripts/setup-local-check-env.sh
+++ b/scripts/setup-local-check-env.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOLS_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/ocrwebapp-local-checks"
+NODE_VERSION="${NODE_VERSION:-22.13.1}"
+VENV_DIR="$TOOLS_ROOT/venv"
+NODE_DIR="$TOOLS_ROOT/node"
+NODE_TOOLS_DIR="$TOOLS_ROOT/node-tools"
+ENV_FILE="$TOOLS_ROOT/env.sh"
+
+detect_node_platform() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Linux) os="linux" ;;
+    Darwin) os="darwin" ;;
+    *)
+      echo "Unsupported OS: $os" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$arch" in
+    x86_64|amd64) arch="x64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *)
+      echo "Unsupported CPU architecture: $arch" >&2
+      exit 1
+      ;;
+  esac
+
+  printf "%s-%s" "$os" "$arch"
+}
+
+install_node() {
+  local platform tmpdir tarball_url
+  platform="$(detect_node_platform)"
+
+  if [[ -x "$NODE_DIR/bin/node" ]]; then
+    return
+  fi
+
+  echo "[setup] install node v$NODE_VERSION ($platform)"
+  tmpdir="$(mktemp -d)"
+  tarball_url="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${platform}.tar.xz"
+  curl -fsSL "$tarball_url" -o "$tmpdir/node.tar.xz"
+  rm -rf "$NODE_DIR"
+  mkdir -p "$NODE_DIR"
+  tar -xJf "$tmpdir/node.tar.xz" --strip-components=1 -C "$NODE_DIR"
+  rm -rf "$tmpdir"
+}
+
+install_python_tools() {
+  echo "[setup] install virtualenv"
+  if python3 -m pip install --help 2>/dev/null | grep -q -- '--break-system-packages'; then
+    python3 -m pip install --user --break-system-packages virtualenv==20.29.3
+  else
+    python3 -m pip install --user virtualenv==20.29.3
+  fi
+
+  if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+    echo "[setup] create python virtualenv"
+    python3 -m virtualenv "$VENV_DIR"
+  fi
+
+  echo "[setup] install yamllint and shellcheck"
+  "$VENV_DIR/bin/pip" install --upgrade pip
+  "$VENV_DIR/bin/pip" install yamllint==1.37.1 shellcheck-py==0.11.0.1
+}
+
+install_node_tools() {
+  echo "[setup] install markdownlint-cli2"
+  mkdir -p "$NODE_TOOLS_DIR"
+  PATH="$NODE_DIR/bin:$PATH" "$NODE_DIR/bin/npm" --prefix "$NODE_TOOLS_DIR" install --no-fund --no-audit markdownlint-cli2@0.18.1
+}
+
+write_env_file() {
+  cat > "$ENV_FILE" <<EOF
+export OCRWEBAPP_CHECK_TOOLS_ROOT="$TOOLS_ROOT"
+export PATH="$VENV_DIR/bin:$NODE_DIR/bin:$NODE_TOOLS_DIR/node_modules/.bin:\$PATH"
+EOF
+}
+
+main() {
+  mkdir -p "$TOOLS_ROOT"
+
+  install_node
+  install_python_tools
+  install_node_tools
+  write_env_file
+
+  echo
+  echo "Local check tools are ready."
+  echo "Tools root: $TOOLS_ROOT"
+  echo "Use: source \"$ENV_FILE\""
+  echo "Then run: bash \"$REPO_ROOT/scripts/run-local-checks.sh\""
+}
+
+main "$@"


### PR DESCRIPTION
## 概要
- ローカルで CI 相当チェックを再現するためのセットアップ/実行スクリプトを追加
- 手順を docs/operations に追加

## 変更内容
- `scripts/setup-local-check-env.sh` を追加
- `scripts/run-local-checks.sh` を追加
- `docs/operations/20260225-local-check-environment.md` を追加

## 実行確認
- `shellcheck scripts/setup-local-check-env.sh scripts/run-local-checks.sh`
- `markdownlint-cli2 docs/operations/20260225-local-check-environment.md`

## 補足
- ツールは `~/.cache/ocrwebapp-local-checks` 配下に導入し、リポジトリ配下を汚さない構成です。