### PR TITLE
docs: READMEをOCRWebAppの現行方針に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,60 @@
-# Codex Repository Template
+# OCRWebApp
 
-Codex（CLI/Agent）での開発を前提にした、**最小で実用的なリポジトリテンプレート**です。
+物件概要書（写真）を OCR/AI で解析し、編集可能な規定フォーマットへ変換して出力するための不動産業務 OS プロジェクトです。  
+現在は **Phase 0（OCRから規定フォーマット化と出力）** を開発対象としています。
 
-## 目的
+## 現在のスコープ（Phase 0）
 
-- 生成AIエージェントが迷いにくいディレクトリ構成を提供する
-- 人間レビューしやすい PR 情報と変更履歴を残しやすくする
-- まずはドキュメント中心で始めて、必要に応じて言語/フレームワークを追加できる形にする
+- Google 認証でログイン
+- 物件概要書画像をアップロード（1物件に複数枚対応）
+- 非同期ジョブで OCR/LLM 解析
+- 規定フォーマットへ正規化
+- 主要項目（価格・賃料・面積など）を編集
+- 抽出根拠と信頼度を保持
+- 確定データを保存し、PDF/CSV で出力
 
-## 含まれるテンプレート
+将来は `property -> deal -> proposal -> simulation -> bank docs -> referral` の順で段階拡張します。
 
-- `AGENTS.md`: エージェント向け作業ルール（スコープ: リポジトリ全体）
-- `.github/pull_request_template.md`: 日本語 PR 記述テンプレート
-- `.github/ISSUE_TEMPLATE/*`: 日本語 Issue テンプレート（不具合/機能要望）
-- `.github/workflows/ci.yml`: 最低限の整合性チェック CI
-- `.github/workflows/release.yml`: タグ作成時の GitHub Release 作成
-- `.github/release.yml`: GitHub Release ノートのカテゴリ定義
-- `scripts/check.sh`: ローカルで実行する軽量チェック
-- `.editorconfig`: エディタ共通設定
-- `.gitignore`: 汎用除外設定
+## 重要な設計方針
 
-## docs 運用ルール
+- OCR の生データ（`extractions`）と確定データ（`normalized_properties`）を分離する
+- 編集履歴（`revisions`）を記録し、誰がいつ何を変えたか追跡可能にする
+- OCR/LLM は API で同期実行せず、必ずジョブを作成して Worker で処理する
+- OCR / LLM / Storage は抽象インターフェース経由で利用し、アプリ層から SDK を直接呼ばない
+- リージョンは東京で統一する（Vercel `hnd1` / Supabase `ap-northeast-1` / Cloud Run `asia-northeast1`）
 
-- ドキュメントは `docs/` 配下で管理し、設計・運用・意思決定を同一リポジトリで追跡する
-- 主要構成:
-  - `docs/requirements`: 要件と受け入れ条件
-  - `docs/design`: 設計情報
-  - `docs/operations`: 運用手順
-  - `docs/adr`: 重要な設計/運用判断（1 ADR = 1 決定）
-- 命名規則:
-  - 要件/設計/運用: `YYYYMMDD-<slug>.md`
-  - ADR: `NNNN-<slug>.md`
-- 主要文書ヘッダ必須項目: `Title` `Status` `Created` `Last Updated` `Owner` `Language`
-- 日英併記方針: 見出しは `日本語 / English` 形式を基本にし、最低限「概要」と「結論」は JA/EN の両方を記載
-- 仕様や挙動に影響する変更では、関連 docs 更新と必要に応じた ADR 追加を PR で必須とする
+## 想定アーキテクチャ
 
-## 使い方
+- Frontend / API: Next.js（App Router）
+- DB: Supabase PostgreSQL
+- ORM: Prisma
+- Auth: NextAuth（Google OAuth）
+- Worker: Cloud Run
+- OCR: Google Vision API
+- LLM 抽出: OpenAI Structured Outputs
 
-1. このテンプレートをベースに新規リポジトリを作成
-2. `README.md` の「プロジェクト固有情報」を追記
-3. `AGENTS.md` をプロジェクトに合わせて更新
-4. `docs/templates/` を使って必要な文書を作成
-5. 必要に応じて `scripts/check.sh` にテスト/リンターを追加
-6. Issue は `.github/ISSUE_TEMPLATE/` のテンプレートから日本語で起票
+詳細は [SPEC.md](./SPEC.md) と `docs/` を参照してください。
 
-## 日本語運用ガイド
+## リポジトリ構成
 
-- PR は `.github/pull_request_template.md` の項目に沿って日本語で記述
-- Issue は「不具合報告 / 機能要望」テンプレートを選んで日本語で記述
-- 空 Issue は無効化（`blank_issues_enabled: false`）して、テンプレート利用を促進
+- `SPEC.md`: 現時点の仕様ドラフト（MVP + システム設計前提）
+- `docs/`: 要件・設計・運用・ADR
+- `scripts/check.sh`: ドキュメントとテンプレートの軽量チェック
+- `tmp/`: 検討メモ（実装判断の一次情報には使わない）
 
-## PRブランチ運用ルール
+## 開発ルール（抜粋）
 
-- ブランチ名は `type/short-slug` 形式を使用する
-- `type` は `feature|fix|chore|docs|refactor|test|ci` のいずれかを使用する
-- `short-slug` は英小文字・数字・ハイフンのみ（先頭末尾ハイフン禁止）
-- ブランチ名は `Branch Name Check` workflow で PR 時に検証する
-- マージ後のブランチ自動削除は GitHub のリポジトリ設定（`Automatically delete head branches`）で有効化する
-- `main` にはブランチ保護を設定し、`CI` と `Branch Name Check` を必須チェックにする（詳細は `docs/operations/20260224-branch-protection-policy.md`）
+- 1 PR 1 目的で小さく安全に変更する
+- 仕様/挙動に影響する変更は `SPEC.md` または `docs/` を同一 PR で更新する
+- PR / Issue / レビューは日本語を基本とする
 
-## リリース運用
-
-- 運用手順: `docs/operations/20260224-release-management-runbook.md`
-- リリースノートひな形: `docs/templates/release-notes-template.md`
-- 変更履歴: `CHANGELOG.md`
-- タグ `v*` を push すると `Release` workflow が GitHub Release を作成する
+詳細は [AGENTS.md](./AGENTS.md) を参照してください。
 
 ## ローカルチェック
 
 ```bash
 bash scripts/check.sh
 ```
-
-## プロジェクト固有情報（記入例）
-
-- 概要:
-- 想定ユーザー:
-- 実行方法:
-- テスト方法:
-- アーキテクチャメモ:
-- 非機能要件（性能/セキュリティ/運用）:
 
 ## ライセンス
 


### PR DESCRIPTION
## 概要\nテンプレート文面のままだったREADMEを、OCRWebAppの現行方針に合わせて更新しました。\n\n## 変更内容\n- プロジェクト概要を Phase 0 前提へ差し替え\n- 現在のスコープ（OCR→正規化→編集→出力）を明記\n- 重要な設計方針（抽出/確定分離・非同期ジョブ・抽象化）を追記\n- 想定アーキテクチャと参照ドキュメント導線（SPEC.md / AGENTS.md）を整備\n\n## 変更ファイル\n- README.md\n\n## 確認\n- [x] bash scripts/check.sh\n