### PR TITLE
chore: ローカルチェック環境と実行スクリプトを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,33 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run lightweight checks
         run: bash scripts/check.sh
+
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e
+        with:
+          globs: |
+            **/*.md
+
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install yamllint
+        run: python -m pip install yamllint==1.37.1
+      - name: Run yamllint
+        run: yamllint .
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: shellcheck scripts/*.sh

--- a/docs/operations/20260225-local-check-environment.md
+++ b/docs/operations/20260225-local-check-environment.md
@@ -40,6 +40,8 @@ bash scripts/setup-local-check-env.sh
 bash scripts/run-local-checks.sh
 ```
 
+`run-local-checks.sh` は実行時に自動でリポジトリルートへ移動してから検証するため、どのカレントディレクトリから呼び出しても同じ結果になる。
+
 実行内容:
 
 - `bash scripts/check.sh`

--- a/scripts/run-local-checks.sh
+++ b/scripts/run-local-checks.sh
@@ -27,8 +27,10 @@ require_cmd markdownlint-cli2
 require_cmd yamllint
 require_cmd shellcheck
 
+cd "$REPO_ROOT"
+
 echo "[local-check] bash scripts/check.sh"
-bash "$REPO_ROOT/scripts/check.sh"
+bash scripts/check.sh
 
 echo "[local-check] markdownlint-cli2"
 markdownlint-cli2 "**/*.md"
@@ -37,10 +39,10 @@ echo "[local-check] yamllint"
 yamllint .
 
 echo "[local-check] shellcheck"
-shellcheck "$REPO_ROOT"/scripts/*.sh
+shellcheck scripts/*.sh
 
 echo "[local-check] branch name"
-branch_name="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
-bash "$REPO_ROOT/scripts/validate-branch-name.sh" "$branch_name"
+branch_name="$(git rev-parse --abbrev-ref HEAD)"
+bash scripts/validate-branch-name.sh "$branch_name"
 
 echo "All local checks passed."


### PR DESCRIPTION
## 概要
ローカルでCI相当のチェックを再現できる環境と実行スクリプトを追加しました。

## 変更内容
- `scripts/setup-local-check-env.sh` を追加
- `scripts/run-local-checks.sh` を追加
- `docs/operations/20260225-local-check-environment.md` を追加
- `.github/workflows/ci.yml` を整理
- `.markdownlint-cli2.yaml` に `tmp/**/*.md` の除外を追加

## 目的
- PR前にローカルで失敗を再現し、CIの手戻りを減らす

## 確認
- `bash scripts/check.sh` 成功
