### PR TITLE
docs: Phase 0着手の意思決定とIssue/PRドラフトを追加

### DIFF
--- a/docs/operations/20260225-phase0-kickoff-issue-pr-drafts.md
+++ b/docs/operations/20260225-phase0-kickoff-issue-pr-drafts.md
@@ -109,12 +109,13 @@ bash scripts/check.sh
 ```
 
 ## 影響範囲・リスク
+
 - DB 初期スキーマのため、後続PRに影響が広い。
 - 命名変更が発生すると下流のAPI/Worker/UIに連鎖するため、今PRで固定する。
 
 ## 補足
+
 - OCRProvider / Extractor / Worker の本処理は別PRで追加する。
-```
 
 ## ロールバック / Rollback
 

--- a/docs/requirements/20260225-phase0-kickoff-decisions.md
+++ b/docs/requirements/20260225-phase0-kickoff-decisions.md
@@ -28,6 +28,7 @@
 採用案:
 
 1. データモデル命名（Phase 0）
+
 - `users`
 - `documents`
 - `extractions`
@@ -35,7 +36,8 @@
 - `revisions`
 - `jobs`
 
-2. API最小スコープ（1本目PR）
+1. API最小スコープ（1本目PR）
+
 - `POST /api/documents`
   - 役割: ファイル保存、`documents` 作成、`jobs(queued)` 作成
   - 禁止: OCR/LLM の同期実行


### PR DESCRIPTION
## 概要
Phase 0の着手前に必要な意思決定と、Issue/PR起票に使うドラフトを追加しました。

## 変更内容
- `docs/requirements/20260225-phase0-kickoff-decisions.md`
- `docs/operations/20260225-phase0-kickoff-issue-pr-drafts.md`

## 目的
- データ命名と最小APIスコープを固定し、実装開始時の判断ブレを減らす
- 起票テンプレートを使って初手PRまでの流れを定型化する

## 確認
- `bash scripts/check.sh` 成功
