### PR TITLE
chore: tmp配下を無視しdocs案内を整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@
 Thumbs.db
 
 # Editor
-.vscode/*
-!.vscode/settings.json
+.vscode/
 .idea/
 *.swp
 
@@ -25,3 +24,6 @@ __pycache__/
 .env
 .env.*
 !.env.example
+
+# Workspace memos
+/tmp/

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,6 @@ This directory stores project documentation alongside code.
 - `operations/`: 運用手順 / Operational runbooks
 - `adr/`: 重要判断記録 / Architectural Decision Records
 - `templates/`: 文書テンプレート / Document templates
-  - `release-notes-template.md`: リリースノート作成用 / Release notes template
 
 ## 命名規則 / Naming
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -5,4 +5,3 @@ Store operational runbooks including release, monitoring, and incident response.
 
 - ファイル名: `YYYYMMDD-<slug>.md`
 - ひな形: `docs/templates/operations-template.md`
-- リリースノートひな形: `docs/templates/release-notes-template.md`


### PR DESCRIPTION
## 概要
作業メモ用ディレクトリ `tmp/` をGit追跡対象から外し、docs案内の重複表現を整理しました。

## 変更内容
- `.gitignore` に `/tmp/` を追加
- `docs/README.md` のテンプレート説明を整理
- `docs/operations/README.md` の重複説明を整理

## 目的
- 検討メモや資料が誤ってコミット対象に入るのを防ぐ
- docsガイドの記載重複を減らす

## 確認
- `bash scripts/check.sh` 成功
