### PR TITLE
feat: Phase 0実装土台のNext.js/API雛形を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,25 @@
 # PostgreSQL (Supabase)
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/ocrwebapp?schema=public"
 
+# App
+NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_SECRET="replace-with-secure-random-string"
+
+# Google OAuth (NextAuth)
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+
+# OCR / LLM
+GOOGLE_CLOUD_PROJECT=""
+GOOGLE_APPLICATION_CREDENTIALS=""
+OPENAI_API_KEY=""
+
+# Storage
+R2_ACCOUNT_ID=""
+R2_ACCESS_KEY_ID=""
+R2_SECRET_ACCESS_KEY=""
+R2_BUCKET=""
+R2_ENDPOINT=""
+
 # Supabase PgBouncer/Pooler URL (when enabled in production)
 # DATABASE_URL="postgresql://USER:PASSWORD@HOST:6543/postgres?pgbouncer=true&connection_limit=1"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Thumbs.db
 node_modules/
 dist/
 coverage/
+.next/
 
 # Python
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@
 - `SPEC.md`: 現時点の仕様ドラフト（MVP + システム設計前提）
 - `docs/`: 要件・設計・運用・ADR
 - `prisma/`: Phase 0 のDBスキーマとマイグレーション
+- `app/`: Next.js App Router（UI + API）
+- `lib/`: DB・認証・Provider抽象などのアプリ共通層
+- `tests/`: ユニットテスト
 - `scripts/check.sh`: ドキュメントとテンプレートの軽量チェック
 - `tmp/`: 検討メモ（実装判断の一次情報には使わない）
 
@@ -56,6 +59,33 @@
 ```bash
 bash scripts/check.sh
 ```
+
+## 実装土台のセットアップ（Phase 0）
+
+```bash
+npm install
+cp .env.example .env
+npx prisma generate
+npx prisma migrate dev
+npm run dev
+```
+
+## テスト
+
+```bash
+npm run test
+```
+
+## API雛形（Phase 0 1本目PR対象）
+
+- `POST /api/documents`
+- `GET /api/jobs/{jobId}`
+- `GET /api/documents/{documentId}`
+
+注記:
+
+- 現在のAPI雛形では暫定的に `x-user-id` ヘッダー（UUID）で認証を代替しています。
+- 次のステップで NextAuth セッション検証へ差し替える前提です。
 
 ## ライセンス
 

--- a/app/api/documents/[documentId]/route.ts
+++ b/app/api/documents/[documentId]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { requireUserId, UnauthorizedError } from "@/lib/auth/session";
+import { isValidUuid } from "@/lib/validation/uuid";
+
+type Params = {
+  params: {
+    documentId: string;
+  };
+};
+
+export async function GET(request: Request, { params }: Params) {
+  try {
+    const userId = requireUserId(request);
+    const { documentId } = params;
+
+    if (!isValidUuid(documentId)) {
+      return NextResponse.json({ error: "invalid_document_id" }, { status: 400 });
+    }
+
+    const document = await prisma.document.findFirst({
+      where: {
+        id: documentId,
+        userId
+      },
+      select: {
+        id: true,
+        filePath: true,
+        createdAt: true,
+        updatedAt: true
+      }
+    });
+
+    if (!document) {
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    }
+
+    return NextResponse.json(document, { status: 200 });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
+  }
+}

--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { requireUserId, UnauthorizedError } from "@/lib/auth/session";
+import { getStorageAdapter } from "@/lib/storage/adapter";
+
+export async function POST(request: Request) {
+  try {
+    const userId = requireUserId(request);
+    const formData = await request.formData();
+    const file = formData.get("file");
+
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: "file is required" }, { status: 400 });
+    }
+
+    const storage = getStorageAdapter();
+    const filePath = await storage.upload(file);
+
+    const result = await prisma.$transaction(async (tx) => {
+      const document = await tx.document.create({
+        data: {
+          userId,
+          filePath
+        }
+      });
+
+      const job = await tx.job.create({
+        data: {
+          documentId: document.id,
+          status: "queued"
+        }
+      });
+
+      return { document, job };
+    });
+
+    return NextResponse.json(
+      {
+        documentId: result.document.id,
+        jobId: result.job.id,
+        status: result.job.status
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
+  }
+}

--- a/app/api/jobs/[jobId]/route.ts
+++ b/app/api/jobs/[jobId]/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { requireUserId, UnauthorizedError } from "@/lib/auth/session";
+import { isValidUuid } from "@/lib/validation/uuid";
+
+type Params = {
+  params: {
+    jobId: string;
+  };
+};
+
+export async function GET(request: Request, { params }: Params) {
+  try {
+    const userId = requireUserId(request);
+    const { jobId } = params;
+
+    if (!isValidUuid(jobId)) {
+      return NextResponse.json({ error: "invalid_job_id" }, { status: 400 });
+    }
+
+    const job = await prisma.job.findFirst({
+      where: {
+        id: jobId,
+        document: {
+          userId
+        }
+      },
+      select: {
+        id: true,
+        status: true,
+        errorMessage: true,
+        updatedAt: true
+      }
+    });
+
+    if (!job) {
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    }
+
+    return NextResponse.json(
+      {
+        jobId: job.id,
+        status: job.status,
+        errorMessage: job.errorMessage,
+        updatedAt: job.updatedAt
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,18 @@
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+}
+
+main {
+  max-width: 800px;
+  margin: 0 auto;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,20 @@
+import "./globals.css";
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "OCRWebApp",
+  description: "Phase 0 foundation"
+};
+
+type RootLayoutProps = {
+  children: ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="ja">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <main>
+      <h1>OCRWebApp Phase 0</h1>
+      <p>Upload API / Job Status API / Document API scaffold is ready.</p>
+    </main>
+  );
+}

--- a/docs/design/20260225-system-architecture.md
+++ b/docs/design/20260225-system-architecture.md
@@ -99,6 +99,12 @@ API同期処理でOCR/LLMを実行しない。
 - Documentは所有者のみアクセス許可
 - Signed URLは短期有効期限
 
+## 実装メモ（2026-02-25時点） / Implementation Notes (as of 2026-02-25)
+
+- Phase 0 の初期実装では、`POST /api/documents` `GET /api/jobs/{jobId}` `GET /api/documents/{documentId}` の雛形を追加済み。
+- 認証は暫定的に `x-user-id` ヘッダー（UUID）で代替し、NextAuthセッション連携へ差し替え予定。
+- Storage は `StorageAdapter` のスタブ実装を経由し、アプリ層でSDK直呼びを行わない構造を先に固定している。
+
 ## 代替案 / Alternatives
 
 - API同期実行案:

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -1,0 +1,18 @@
+import { isValidUuid } from "@/lib/validation/uuid";
+
+export class UnauthorizedError extends Error {
+  constructor(message = "Unauthorized") {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}
+
+// Temporary auth adapter for initial API development.
+// Replace this with NextAuth session integration in the next step.
+export function requireUserId(request: Request): string {
+  const userId = request.headers.get("x-user-id")?.trim();
+  if (!userId || !isValidUuid(userId)) {
+    throw new UnauthorizedError();
+  }
+  return userId;
+}

--- a/lib/db/prisma.ts
+++ b/lib/db/prisma.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"]
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/lib/jobs/status.ts
+++ b/lib/jobs/status.ts
@@ -1,0 +1,13 @@
+export const jobStatuses = ["queued", "processing", "succeeded", "failed"] as const;
+export type JobStatus = (typeof jobStatuses)[number];
+
+const transitions: Record<JobStatus, JobStatus[]> = {
+  queued: ["processing", "failed"],
+  processing: ["succeeded", "failed"],
+  succeeded: [],
+  failed: []
+};
+
+export function isValidJobTransition(from: JobStatus, to: JobStatus): boolean {
+  return transitions[from].includes(to);
+}

--- a/lib/storage/adapter.ts
+++ b/lib/storage/adapter.ts
@@ -1,0 +1,24 @@
+export interface StorageAdapter {
+  upload(file: File): Promise<string>;
+  getSignedUrl(path: string): Promise<string>;
+  delete(path: string): Promise<void>;
+}
+
+class LocalStubStorageAdapter implements StorageAdapter {
+  async upload(file: File): Promise<string> {
+    const now = new Date().toISOString().replace(/[:.]/g, "-");
+    return `stub/${now}-${file.name}`;
+  }
+
+  async getSignedUrl(path: string): Promise<string> {
+    return `https://example.invalid/${encodeURIComponent(path)}`;
+  }
+
+  async delete(_path: string): Promise<void> {
+    return;
+  }
+}
+
+export function getStorageAdapter(): StorageAdapter {
+  return new LocalStubStorageAdapter();
+}

--- a/lib/validation/uuid.ts
+++ b/lib/validation/uuid.ts
@@ -1,0 +1,6 @@
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isValidUuid(value: string): boolean {
+  return UUID_V4_PATTERN.test(value);
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ocrwebapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate:dev": "prisma migrate dev"
+  },
+  "dependencies": {
+    "@prisma/client": "^6.4.1",
+    "next": "15.2.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "@types/react": "^19.0.10",
+    "@types/react-dom": "^19.0.4",
+    "eslint": "^9.21.0",
+    "eslint-config-next": "15.2.0",
+    "prisma": "^6.4.1",
+    "typescript": "^5.8.2",
+    "vitest": "^3.0.8"
+  }
+}

--- a/tests/unit/job-status.test.ts
+++ b/tests/unit/job-status.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isValidJobTransition } from "@/lib/jobs/status";
+
+describe("isValidJobTransition", () => {
+  it("allows queued -> processing", () => {
+    expect(isValidJobTransition("queued", "processing")).toBe(true);
+  });
+
+  it("allows processing -> failed", () => {
+    expect(isValidJobTransition("processing", "failed")).toBe(true);
+  });
+
+  it("rejects succeeded -> processing", () => {
+    expect(isValidJobTransition("succeeded", "processing")).toBe(false);
+  });
+});

--- a/tests/unit/uuid.test.ts
+++ b/tests/unit/uuid.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isValidUuid } from "@/lib/validation/uuid";
+
+describe("isValidUuid", () => {
+  it("returns true for valid UUID", () => {
+    expect(isValidUuid("9f4e4a5f-7a4d-4a7f-b006-9225f39ae4d8")).toBe(true);
+  });
+
+  it("returns false for invalid value", () => {
+    expect(isValidUuid("invalid-id")).toBe(false);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"]
+  }
+});


### PR DESCRIPTION
## 概要
- Phase 0 1本目PR対象の API 雛形とアプリ実行土台を追加
- Next.js App Router 構成と最小テスト基盤（Vitest）を導入

## 変更内容
- Next.js 実行設定: `package.json`, `tsconfig.json`, `next.config.mjs`
- API 雛形:
  - `POST /api/documents`
  - `GET /api/jobs/{jobId}`
  - `GET /api/documents/{documentId}`
- 共通層追加: 認証ヘルパー、Prisma client、StorageAdapterスタブ、UUID検証、Job状態遷移
- Unit テスト追加: `tests/unit/job-status.test.ts`, `tests/unit/uuid.test.ts`
- docs 更新: `README.md`, `docs/design/20260225-system-architecture.md`

## 確認
- `bash scripts/check.sh` : 成功
- `node/npm` が実行環境にないため `npm run test` は未実行

## ベースPR
- #13
