### PR TITLE
chore: Dev Containerとdocker-composeのローカル環境を追加

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends postgresql-client \
+  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "OCRWebApp Dev Container",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "shutdownAction": "stopCompose",
+  "forwardPorts": [3000, 5432],
+  "postCreateCommand": "npm install && npx prisma generate",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Prisma.prisma",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+dist
+coverage
+.git
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@
 bash scripts/check.sh
 ```
 
+## 仮想化開発環境（推奨）
+
+前提:
+
+- Docker Desktop
+- VS Code + Dev Containers 拡張
+
+手順:
+
+1. VS Code で本リポジトリを開く。
+2. `Dev Containers: Reopen in Container` を実行する。
+3. コンテナ起動後、以下を実行する。
+
+```bash
+cp .env.example .env
+npx prisma migrate dev
+npm run dev
+```
+
+`docker-compose.yml` で `app` と `db(PostgreSQL)` を起動し、`DATABASE_URL` は `db:5432` を参照する。
+
 ## 実装土台のセットアップ（Phase 0）
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+    working_dir: /workspace
+    command: sleep infinity
+    volumes:
+      - .:/workspace:cached
+    environment:
+      NODE_ENV: development
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/ocrwebapp?schema=public
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ocrwebapp
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:

--- a/docs/operations/20260225-devcontainer-local-environment.md
+++ b/docs/operations/20260225-devcontainer-local-environment.md
@@ -1,0 +1,57 @@
+# Dev Container ローカル開発環境手順 / Dev Container Local Environment Runbook
+
+- Title: Dev Container ローカル開発環境手順 / Dev Container Local Environment Runbook
+- Status: Draft
+- Created: 2026-02-25
+- Last Updated: 2026-02-25
+- Owner: TBD
+- Language: JA/EN
+
+## 前提 / Preconditions
+
+- Docker Desktop が起動している。
+- VS Code に Dev Containers 拡張がインストールされている。
+- リポジトリルートに `.devcontainer/devcontainer.json` と `docker-compose.yml` が存在する。
+
+## 手順 / Procedure
+
+1. VS Code でリポジトリを開く。
+2. `Dev Containers: Reopen in Container` を実行する。
+3. コンテナ初回起動時に `npm install` と `npx prisma generate` の post-create が実行される。
+4. コンテナターミナルで `cp .env.example .env` を実行する。
+5. `npx prisma migrate dev` でローカルDBへマイグレーションを適用する。
+6. `npm run dev` でアプリを起動する。
+7. 必要に応じて `npm run test` と `bash scripts/check.sh` を実行する。
+
+## ロールバック / Rollback
+
+- 環境破損時は `Dev Containers: Rebuild Container` を実行する。
+- DBを初期化する場合は `docker compose down -v` 後に再起動する。
+
+## 監視項目 / Monitoring
+
+- `docker compose ps` で `app` と `db` が `running` であること。
+- `npm run dev` 実行時に `http://localhost:3000` で応答があること。
+- `npx prisma migrate dev` が失敗していないこと。
+
+## 障害時対応 / Incident Response
+
+- `npm install` 失敗時はコンテナ内で Node バージョンを確認し、再ビルドする。
+- DB接続失敗時は `DATABASE_URL` が `db:5432` を向いているか確認する。
+- `postCreateCommand` が途中失敗した場合はコンテナ内で手動再実行する。
+
+## 概要 / Summary (JA)
+
+Dev Container と Docker Compose を使って Node.js と PostgreSQL の実行環境を固定し、実装開始時の環境差分を最小化する。
+
+## Summary (EN)
+
+Use Dev Container and Docker Compose to standardize Node.js and PostgreSQL local runtime and minimize environment drift at implementation kickoff.
+
+## 結論 / Conclusion (JA)
+
+Phase 0 のローカル実装は本手順を標準とし、例外運用を行う場合は理由を運用docsに追記する。
+
+## Conclusion (EN)
+
+Use this runbook as the default local setup for Phase 0. Document any exceptions with rationale in operations docs.


### PR DESCRIPTION
## 概要
- 実装開始時の環境差分を減らすため、Dev Container + Docker Compose 環境を追加

## 変更内容
- `.devcontainer/devcontainer.json` を追加
- `.devcontainer/Dockerfile` を追加（Node + PostgreSQL client）
- `docker-compose.yml` を追加（`app` + `db`）
- `.dockerignore` を追加
- `docs/operations/20260225-devcontainer-local-environment.md` を追加
- `README.md` に仮想化手順を追記

## 確認
- `bash scripts/check.sh` : 成功
- Docker 実行確認は未実施（この実行環境では確認不可）

## ベースPR
- #15
