### PR TITLE
fix: PostCSS 設定追加による Tailwind v4 ユーティリティ生成修正

### DIFF
--- a/apps/web/postcss.config.mjs
+++ b/apps/web/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;


### PR DESCRIPTION
## 概要

postcss.config.mjs が main に存在せず、Tailwind CSS v4 のユーティリティクラスが一切生成されていなかった問題を修正。

## 原因

PR #76 で Tailwind v4 + shadcn/ui を導入したが、`apps/web/postcss.config.mjs` が別ブランチ（PR #75）にのみ存在し main にマージされなかった。結果として `@tailwind utilities` が未解決のまま CSS に出力され、`flex`, `bg-background`, `rounded-lg` 等のユーティリティクラスが全て無効 → 文字だけの画面になっていた。

## 修正内容

- `apps/web/postcss.config.mjs` を追加（`@tailwindcss/postcss` プラグイン設定）

## テスト計画

- [x] `npm run build` — ビルド成功
- [x] `npm run test` — 全 95 テスト PASS
- [x] ビルド後の CSS に `@tailwind utilities` が残っていないことを確認
- [x] ユーティリティクラス (flex, bg-card, rounded-lg 等) が CSS に生成されることを確認
- [ ] 本番でモダンなスタイリングが適用されることを目視確認